### PR TITLE
Optimization to only visit messages that were sent by user ("You")

### DIFF
--- a/src/ui/default/dom-lookup.js
+++ b/src/ui/default/dom-lookup.js
@@ -10,6 +10,7 @@ import { waitForElement } from "../../dom/async-events.js"
  */
 export function getFirstVisibleMessage(root, abortController) {
 	const elements = [...root.querySelectorAll("div[role=row]:not([data-idmu-ignore])")]
+		.filter(d => d.textContent.length > 3 && d.textContent.substring(0, 3) == "You");
 	elements.reverse()
 	console.debug("getFirstVisibleMessage", elements.length, "elements")
 	for(const element of elements) {

--- a/src/ui/default/dom-lookup.js
+++ b/src/ui/default/dom-lookup.js
@@ -10,7 +10,7 @@ import { waitForElement } from "../../dom/async-events.js"
  */
 export function getFirstVisibleMessage(root, abortController) {
 	const elements = [...root.querySelectorAll("div[role=row]:not([data-idmu-ignore])")]
-		.filter(d => d.textContent.length > 3 && d.textContent.substring(0, 3) == "You");
+		.filter(d => d.textContent.length > 3 && d.textContent.substring(0, 3) === "You")
 	elements.reverse()
 	console.debug("getFirstVisibleMessage", elements.length, "elements")
 	for(const element of elements) {

--- a/src/ui/default/dom-lookup.test.js
+++ b/src/ui/default/dom-lookup.test.js
@@ -21,6 +21,13 @@ test("getFirstVisibleMessage ignore if already processed", async t => {
 	t.is(await getFirstVisibleMessage(t.context.document.body, new AbortController()), undefined)
 })
 
+test("getFirstVisibleMessage ignore if sent by someone else", async t => {
+	const messageElement = createMessageElement(t.context.document, "Test", false, true)
+	t.context.mountElement.append(messageElement)
+	messageElement.getBoundingClientRect = () => ({ y: 105 })
+	t.is(await getFirstVisibleMessage(t.context.document.body, new AbortController()), undefined)
+})
+
 test("findMessagesWrapper", t => {
 	const messagesWrapperElement = createMessagesWrapperElement(t.context.document)
 	t.context.mountElement.append(messagesWrapperElement)

--- a/test/fake-ui.js
+++ b/test/fake-ui.js
@@ -102,7 +102,7 @@ export function createMessageElement(document, text="", includesUnsend=true, ign
 	if(ignored) {
 		element.setAttribute("data-idmu-ignore", "true")
 	}
-	element.innerHTML = `<span>${text}</span>`
+	element.innerHTML = `${includesUnsend?"<span>You sent</span>":""}<span>${text}</span>`
 	element.addEventListener("mouseover", event => {
 		console.debug(`message ${text} mouseover`)
 		setTimeout(() => {


### PR DESCRIPTION
I had a long thread on instagram that I wanted to delete and I noticed that the script was visiting each and every message while moving up. Even the ones that were sent by other participant.
It was taking long so I looked at a way to identify user messages without relying on theme.
Apparently the messages that are sent by user have their textContent in following format.
"You replied to\n<message content>"
"You sent\n<message content>"

I added this temporarily to the script and it sped things up a lot. Might be useful for the main script.