### PR TITLE
Fix stop cancellation and wrapper fallback

### DIFF
--- a/src/runtime/userscript/osd/osd.js
+++ b/src/runtime/userscript/osd/osd.js
@@ -99,6 +99,9 @@ class OSD {
 		try {
 			await this.strategy.run()
 		} catch(error) {
+			if(this.strategy._abortController?.signal.aborted) {
+				return
+			}
 			console.error(error)
 			if(this.strategy.isRunning()) {
 				this.strategy.stop()

--- a/src/runtime/userscript/osd/osd.test.js
+++ b/src/runtime/userscript/osd/osd.test.js
@@ -46,6 +46,25 @@ test("userscript osd unsend button", t => {
 	t.is(overlayElement.style.display, "none")
 })
 
+test("userscript osd stop does not render error status when aborted run rejects", async t => {
+	const ui = OSD.render(t.context.window)
+	const button = t.context.window.document.querySelectorAll("button")[0]
+	let rejectRun
+	mock.method(ui.strategy, "run", () => {
+		ui.strategy._running = true
+		ui.strategy._abortController = new t.context.window.AbortController()
+		return new Promise((_, reject) => {
+			rejectRun = reject
+		})
+	})
+
+	button.click()
+	button.click()
+	rejectRun(new Error("waitForElement aborted: DefaultStrategy stopped"))
+	await new Promise(resolve => setTimeout(resolve, 0))
+
+	t.false(ui.statusElement.textContent.includes("An error"))
+})
 
 test("userscript status", t => {
 	const ui = OSD.render(t.context.window)
@@ -53,4 +72,3 @@ test("userscript status", t => {
 	ui.onStatusText("test")
 	t.is(t.context.document.querySelector("#idmu-status").textContent, "test")
 })
-

--- a/src/ui/default/dom-lookup.js
+++ b/src/ui/default/dom-lookup.js
@@ -12,14 +12,53 @@ import { waitForElement } from "../../dom/async-events.js"
  */
 export function findMessagesWrapper(window) {
 	const conversation = window.document.querySelector("[data-pagelet='IGDMessagesList']")
-	if (!conversation) {
-		return null
+	if (conversation) {
+		const scrollable = findScrollableChild(conversation, window)
+		if (scrollable) {
+			return scrollable
+		}
 	}
-	const scrollable = findScrollableChild(conversation, window)
-	if (!scrollable) {
-		return null
+	return findScrollableMessageAncestor(window)
+}
+
+/**
+ * @param {Window} window
+ * @returns {HTMLDivElement|null}
+ */
+function findScrollableMessageAncestor(window) {
+	const messages = window.document.querySelectorAll("[role=none], [role=presentation]")
+	for (const message of messages) {
+		const scrollable = findScrollableAncestor(message.parentElement, window)
+		if (scrollable) {
+			return scrollable
+		}
 	}
-	return scrollable
+	return null
+}
+
+/**
+ * @param {Element} element
+ * @param {Window} window
+ * @returns {HTMLDivElement|null}
+ */
+function findScrollableAncestor(element, window) {
+	while (element && element !== window.document.body) {
+		if (isScrollableElement(element, window)) {
+			return element
+		}
+		element = element.parentElement
+	}
+	return null
+}
+
+/**
+ * @param {Element} element
+ * @param {Window} window
+ * @returns {boolean}
+ */
+function isScrollableElement(element, window) {
+	const style = window.getComputedStyle(element)
+	return (style.overflowY === "auto" || style.overflowY === "scroll") && element.scrollHeight > element.clientHeight
 }
 
 /**
@@ -31,11 +70,7 @@ export function findMessagesWrapper(window) {
  */
 export function findScrollableChild(parent, window) {
 	for (const child of parent.children) {
-		const style = window.getComputedStyle(child)
-		if (
-			(style.overflowY === "auto" || style.overflowY === "scroll") &&
-			child.scrollHeight > child.clientHeight
-		) {
+		if (isScrollableElement(child, window)) {
 			return child
 		}
 		const found = findScrollableChild(child, window)

--- a/src/ui/default/dom-lookup.test.js
+++ b/src/ui/default/dom-lookup.test.js
@@ -52,6 +52,16 @@ test("findMessagesWrapper", t => {
 	t.not(findMessagesWrapper(t.context.window), null)
 })
 
+test("findMessagesWrapper falls back to scrollable message ancestor", t => {
+	const wrapper = t.context.document.createElement("div")
+	wrapper.style.overflowY = "auto"
+	Object.defineProperty(wrapper, "scrollHeight", { value: 1000, configurable: true })
+	Object.defineProperty(wrapper, "clientHeight", { value: 500, configurable: true })
+	wrapper.append(createMessageElement(t.context.document, "Test"))
+	t.context.mountElement.append(wrapper)
+	t.is(findMessagesWrapper(t.context.window), wrapper)
+})
+
 test("findMessagesWrapper returns null without conversation", t => {
 	// No aria-label="Conversation..." element present
 	t.is(findMessagesWrapper(t.context.window), null)


### PR DESCRIPTION
## Summary

Fixes two small regressions seen while testing `v0.7.2`:

- manually clicking `Stop processing` can render the generic error state
- some Direct layouts still need a fallback when `[data-pagelet='IGDMessagesList']` is not the scrollable message container path

## Changes

- Ignore `strategy.run()` rejections after the strategy has already been aborted by the user.
- Fall back to the closest scrollable ancestor of visible message content when the primary wrapper selector does not resolve a scrollable container.
- Add regression tests for both cases.

## Validation

- `npm test`
- `npm run lint:ecmascript`
- `npm run build`
- `npm audit --audit-level=moderate`

`npm audit --audit-level=moderate` exits cleanly. It still reports existing low-severity `jsdom` dependency findings, which this PR intentionally does not change to keep the patch small.
